### PR TITLE
Add page component mapping

### DIFF
--- a/src/lib/storyblok.ts
+++ b/src/lib/storyblok.ts
@@ -5,6 +5,7 @@ import { apiPlugin, storyblokInit } from "@storyblok/react/rsc";
 import Navbar        from "@/storyblok-components/Navbar";
 import EventCard     from "@/storyblok-components/EventCard";
 import FiltersDrawer from "@/storyblok-components/FiltersDrawer";
+import Page          from "@/storyblok-components/Page";
 
 console.log(
   "🪄 Storyblok token seen by Node:",
@@ -18,6 +19,7 @@ export const getStoryblokApi = storyblokInit({
     navbar: Navbar,
     event_card: EventCard,
     filters_drawer: FiltersDrawer,
+    page: Page,
   },
 });
 

--- a/src/storyblok-components/Page.tsx
+++ b/src/storyblok-components/Page.tsx
@@ -1,0 +1,11 @@
+import { StoryblokComponent, storyblokEditable } from "@storyblok/react/rsc";
+
+export default function Page({ blok }: any) {
+  return (
+    <main {...storyblokEditable(blok)}>
+      {blok.body?.map((nestedBlok: any) => (
+        <StoryblokComponent blok={nestedBlok} key={nestedBlok._uid} />
+      ))}
+    </main>
+  );
+}

--- a/src/storyblok-components/index.ts
+++ b/src/storyblok-components/index.ts
@@ -1,3 +1,5 @@
 export { default as Navbar } from "./Navbar";
 export { default as EventCard } from "./EventCard";
 export { default as FiltersDrawer } from "./FiltersDrawer";
+export { default as Page } from "./Page";
+


### PR DESCRIPTION
## Summary
- add a `Page` Storyblok component
- export the new component
- map `page` component in Storyblok setup

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_684b7051d8e08327bc5452e4c5d93197