### PR TITLE
Add Teaser and Grid Storyblok components

### DIFF
--- a/src/lib/storyblok.ts
+++ b/src/lib/storyblok.ts
@@ -6,6 +6,8 @@ import Navbar        from "@/storyblok-components/Navbar";
 import EventCard     from "@/storyblok-components/EventCard";
 import FiltersDrawer from "@/storyblok-components/FiltersDrawer";
 import Page          from "@/storyblok-components/Page";
+import Grid          from "@/storyblok-components/Grid";
+import Teaser        from "@/storyblok-components/Teaser";
 
 // storyblokInit RETURNS a getStoryblokApi function ➜ we re-export it
 export const getStoryblokApi = storyblokInit({
@@ -16,6 +18,8 @@ export const getStoryblokApi = storyblokInit({
     event_card: EventCard,
     filters_drawer: FiltersDrawer,
     page: Page,
+    grid: Grid,
+    teaser: Teaser,
   },
 });
 

--- a/src/storyblok-components/Grid.tsx
+++ b/src/storyblok-components/Grid.tsx
@@ -1,0 +1,15 @@
+import { storyblokEditable, StoryblokServerComponent } from "@storyblok/react/rsc";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function Grid({ blok }: any) {
+  return (
+    <div {...storyblokEditable(blok)} className="grid gap-6 md:grid-cols-3">
+      {blok.columns?.map(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (nestedBlok: any) => (
+          <StoryblokServerComponent blok={nestedBlok} key={nestedBlok._uid} />
+        )
+      )}
+    </div>
+  );
+}

--- a/src/storyblok-components/Teaser.tsx
+++ b/src/storyblok-components/Teaser.tsx
@@ -1,0 +1,10 @@
+import { storyblokEditable } from "@storyblok/react/rsc";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function Teaser({ blok }: any) {
+  return (
+    <h2 {...storyblokEditable(blok)} className="my-4 text-2xl font-semibold">
+      {blok.headline}
+    </h2>
+  );
+}

--- a/src/storyblok-components/index.ts
+++ b/src/storyblok-components/index.ts
@@ -2,4 +2,6 @@ export { default as Navbar } from "./Navbar";
 export { default as EventCard } from "./EventCard";
 export { default as FiltersDrawer } from "./FiltersDrawer";
 export { default as Page } from "./Page";
+export { default as Grid } from "./Grid";
+export { default as Teaser } from "./Teaser";
 

--- a/storyblok/components.342149.json
+++ b/storyblok/components.342149.json
@@ -33,6 +33,18 @@
       "display_name": "Page",
       "is_root":  true,
       "schema":   { "body": { "type": "bloks" } }
+    },
+    {
+      "name": "grid",
+      "display_name": "Grid",
+      "is_nestable": true,
+      "schema": { "columns": { "type": "bloks" } }
+    },
+    {
+      "name": "teaser",
+      "display_name": "Teaser",
+      "is_nestable": true,
+      "schema": { "headline": { "type": "text" } }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- implement missing `Teaser` and `Grid` components
- export them from component index
- register new components with Storyblok
- document new components in `components.342149.json`

## Testing
- `npm run lint`
- `npm run build` *(fails: Error occurred prerendering page '/')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684c4a065d508327bc9732d5c8011de6