### PR TITLE
Add missing Feature component

### DIFF
--- a/src/lib/storyblok.ts
+++ b/src/lib/storyblok.ts
@@ -8,6 +8,7 @@ import FiltersDrawer from "@/storyblok-components/FiltersDrawer";
 import Page          from "@/storyblok-components/Page";
 import Grid          from "@/storyblok-components/Grid";
 import Teaser        from "@/storyblok-components/Teaser";
+import Feature       from "@/storyblok-components/Feature";
 
 // storyblokInit RETURNS a getStoryblokApi function ➜ we re-export it
 export const getStoryblokApi = storyblokInit({
@@ -20,6 +21,7 @@ export const getStoryblokApi = storyblokInit({
     page: Page,
     grid: Grid,
     teaser: Teaser,
+    feature: Feature,
   },
 });
 

--- a/src/storyblok-components/Feature.tsx
+++ b/src/storyblok-components/Feature.tsx
@@ -1,0 +1,10 @@
+import { storyblokEditable } from "@storyblok/react/rsc";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function Feature({ blok }: any) {
+  return (
+    <div {...storyblokEditable(blok)} className="py-4 text-center">
+      <h3 className="text-lg font-semibold">{blok.name}</h3>
+    </div>
+  );
+}

--- a/src/storyblok-components/index.ts
+++ b/src/storyblok-components/index.ts
@@ -4,4 +4,5 @@ export { default as FiltersDrawer } from "./FiltersDrawer";
 export { default as Page } from "./Page";
 export { default as Grid } from "./Grid";
 export { default as Teaser } from "./Teaser";
+export { default as Feature } from "./Feature";
 

--- a/storyblok/components.342149.json
+++ b/storyblok/components.342149.json
@@ -45,6 +45,12 @@
       "display_name": "Teaser",
       "is_nestable": true,
       "schema": { "headline": { "type": "text" } }
+    },
+    {
+      "name": "feature",
+      "display_name": "Feature",
+      "is_nestable": true,
+      "schema": { "name": { "type": "text" } }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a `Feature` component for Storyblok
- export the component and map it in Storyblok init
- document `feature` in the sample components JSON

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c5186affc8327b952e2ae8dd3bd09