### PR TITLE
Add aggregated events API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# API tokens for external services
+EVENTBRITE_TOKEN=
+MEETUP_KEY=
+TICKETMASTER_KEY=
+OPENAI_API_KEY=
+
+# Base URL of the site (used for server fetches)
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -34,3 +34,23 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment variables
+
+Copy `.env.example` to `.env` and fill in the tokens for the external APIs you want to use:
+
+```
+cp .env.example .env
+```
+
+- `EVENTBRITE_TOKEN` – API token for Eventbrite
+- `MEETUP_KEY` – API key for Meetup
+- `TICKETMASTER_KEY` – API key for Ticketmaster
+- `OPENAI_API_KEY` – OpenAI API key used to enrich events
+- `NEXT_PUBLIC_BASE_URL` – base URL of your site
+
+## Events API
+
+The application exposes a `GET /api/events` route that aggregates events from the configured providers and enriches them with a short summary and tags using ChatGPT.
+
+Visit `/events` to see the aggregated list rendered in the UI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@storyblok/react": "^5.0.0",
         "next": "15.3.3",
+        "openai": "^5.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -4579,6 +4580,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.3.0.tgz",
+      "integrity": "sha512-VIKmoF7y4oJCDOwP/oHXGzM69+x0dpGFmN9QmYO+uPbLFOmmnwO+x1GbsgUtI+6oraxomGZ566Y421oYVu191w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@storyblok/react": "^5.0.0",
     "next": "15.3.3",
+    "openai": "^5.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from 'next/server';
+import { Configuration, OpenAIApi } from 'openai';
+
+// Helper function to fetch events from Eventbrite
+async function fetchEventbriteEvents() {
+  const token = process.env.EVENTBRITE_TOKEN;
+  if (!token) return [];
+  const res = await fetch('https://www.eventbriteapi.com/v3/events/search/?location.address=online', {
+    headers: { Authorization: `Bearer ${token}` },
+    next: { revalidate: 60 * 15 },
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.events || [];
+}
+
+// Helper function to fetch events from Meetup
+async function fetchMeetupEvents() {
+  const key = process.env.MEETUP_KEY;
+  if (!key) return [];
+  const res = await fetch(`https://api.meetup.com/find/upcoming_events?&sign=true&key=${key}`);
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data.events || [];
+}
+
+// Helper function to fetch events from Ticketmaster
+async function fetchTicketmasterEvents() {
+  const key = process.env.TICKETMASTER_KEY;
+  if (!key) return [];
+  const res = await fetch(`https://app.ticketmaster.com/discovery/v2/events.json?apikey=${key}`);
+  if (!res.ok) return [];
+  const data = await res.json();
+  return data._embedded?.events || [];
+}
+
+interface FetchedEvent {
+  id: string;
+  name?: { text?: string } | string;
+  url?: string;
+  description?: { text?: string } | string;
+  start?: { local?: string } | string;
+  local_date?: string;
+  venue?: { name?: string };
+  _embedded?: { venues?: { name?: string }[] };
+}
+
+interface EnrichedEvent {
+  id: string;
+  title: string;
+  url?: string;
+  start?: string;
+  venue?: string;
+  summary: string;
+  tags: string[];
+}
+
+async function generateEventMetadata(event: FetchedEvent, openai: OpenAIApi) {
+  const description = event.description?.text || event.description || '';
+  const prompt = `Summarize this event in one sentence and provide a list of relevant tags.\nEvent: ${event.name?.text || event.name}\nDescription: ${description}`;
+  const response = await openai.createChatCompletion({
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+  });
+  const text = response.data.choices[0].message?.content || '';
+  const [summary, tagsLine] = text.split('\n');
+  const tags = tagsLine?.replace('Tags:', '').split(',').map(t => t.trim()).filter(Boolean) || [];
+  return { summary, tags };
+}
+
+export async function GET() {
+  const events = [
+    ...(await fetchEventbriteEvents()),
+    ...(await fetchMeetupEvents()),
+    ...(await fetchTicketmasterEvents()),
+  ].slice(0, 50); // limit to 50 events
+
+  const openaiKey = process.env.OPENAI_API_KEY;
+  const configuration = new Configuration({ apiKey: openaiKey });
+  const openai = new OpenAIApi(configuration);
+
+  const enriched: EnrichedEvent[] = [];
+  for (const event of events as FetchedEvent[]) {
+    try {
+      const metadata = openaiKey ? await generateEventMetadata(event, openai) : { summary: '', tags: [] };
+      enriched.push({
+        id: event.id,
+        title: event.name?.text || event.name,
+        url: event.url,
+        start: event.start?.local || event.local_date,
+        venue: event.venue?.name || event._embedded?.venues?.[0]?.name || '',
+        summary: metadata.summary,
+        tags: metadata.tags,
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return NextResponse.json({ events: enriched });
+}

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,0 +1,41 @@
+import EventCard from '@/storyblok-components/EventCard';
+
+interface ApiEvent {
+  id: string;
+  title: string;
+  url: string;
+  start: string;
+  venue: string;
+  summary: string;
+  tags: string[];
+}
+
+export default async function EventsPage() {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/events`, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error('Failed to load events');
+  }
+  const data = await res.json();
+  const events: ApiEvent[] = data.events;
+
+  return (
+    <div className="space-y-6 p-6">
+      <h1 className="text-2xl font-semibold">Upcoming Events</h1>
+      <div className="grid gap-6 md:grid-cols-3">
+        {events.map(event => (
+          <EventCard
+            key={event.id}
+            blok={{
+              _uid: event.id,
+              image: { filename: '/placeholder.jpg' },
+              title: event.title,
+              start: event.start,
+              venue: event.venue,
+              price: '',
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/api/events` route that merges data from Eventbrite, Meetup and Ticketmaster APIs and enriches each event with ChatGPT
- add `/events` page to render aggregated event cards
- document environment variables
- include `.env.example`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c61c9e5048327bcddf063c2d4bd1e