### PR TITLE
Display event summaries and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ cp .env.example .env
 
 The application exposes a `GET /api/events` route that aggregates events from the configured providers and enriches them with a short summary and tags using ChatGPT.
 
-Visit `/events` to see the aggregated list rendered in the UI.
+Visit `/events` to see the aggregated list rendered in the UI. Each event card displays the AI-generated summary and tags so you can quickly scan for topics of interest.

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -25,14 +25,16 @@ export default async function EventsPage() {
         {events.map(event => (
           <EventCard
             key={event.id}
-            blok={{
-              _uid: event.id,
-              image: { filename: '/placeholder.jpg' },
-              title: event.title,
-              start: event.start,
-              venue: event.venue,
-              price: '',
-            }}
+          blok={{
+            _uid: event.id,
+            image: { filename: '/placeholder.jpg' },
+            title: event.title,
+            start: event.start,
+            venue: event.venue,
+            summary: event.summary,
+            tags: event.tags,
+            price: '',
+          }}
           />
         ))}
       </div>

--- a/src/storyblok-components/EventCard.tsx
+++ b/src/storyblok-components/EventCard.tsx
@@ -19,6 +19,21 @@ export default function EventCard({ blok }: any) {
         <span className="text-xs text-slate-500">{blok.start}</span>
         <h3 className="text-lg font-medium">{blok.title}</h3>
         <p className="text-sm text-slate-600">{blok.venue}</p>
+        {blok.summary && (
+          <p className="text-sm text-slate-700 mt-2">{blok.summary}</p>
+        )}
+        {blok.tags && blok.tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {blok.tags.map((tag: string) => (
+              <span
+                key={tag}
+                className="bg-slate-200 text-slate-600 text-xs rounded px-2 py-0.5"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
         <span className="inline-block mt-2 bg-orange-500 text-white text-xs rounded px-2 py-0.5">
           {blok.price || "Free"}
         </span>


### PR DESCRIPTION
## Summary
- show AI-generated event summaries and tags in EventCard
- pass summary and tags on the events page
- mention summaries and tags in the README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c6a798f308327ac2d0bc99f717363