### PR TITLE
Add STORYBLOK_TOKEN env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ EVENTBRITE_TOKEN=
 MEETUP_KEY=
 TICKETMASTER_KEY=
 OPENAI_API_KEY=
+STORYBLOK_TOKEN=
 
 # Base URL of the site (used for server fetches)
 NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ cp .env.example .env
 - `MEETUP_KEY` – API key for Meetup
 - `TICKETMASTER_KEY` – API key for Ticketmaster
 - `OPENAI_API_KEY` – OpenAI API key used to enrich events
+- `STORYBLOK_TOKEN` – Storyblok API token used for content fetching
 - `NEXT_PUBLIC_BASE_URL` – base URL of your site
 
 ## Events API

--- a/src/lib/storyblok.ts
+++ b/src/lib/storyblok.ts
@@ -11,8 +11,13 @@ import Teaser        from "@/storyblok-components/Teaser";
 import Feature       from "@/storyblok-components/Feature";
 
 // storyblokInit RETURNS a getStoryblokApi function ➜ we re-export it
+const accessToken = process.env.STORYBLOK_TOKEN;
+if (!accessToken) {
+  throw new Error("STORYBLOK_TOKEN environment variable is missing");
+}
+
 export const getStoryblokApi = storyblokInit({
-  accessToken: "YSb54AnQcc8czORhorTRVAtt",
+  accessToken,
   use: [apiPlugin],                 // ← plugin really loaded now
   components: {
     navbar: Navbar,


### PR DESCRIPTION
## Summary
- introduce `STORYBLOK_TOKEN` variable in `.env.example`
- document the new variable in the README
- load Storyblok access token from `process.env.STORYBLOK_TOKEN`
- throw an error if the token is missing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684c75bcb8648327bf2e3fae342187d7