### PR TITLE
Add typed Storyblok interfaces

### DIFF
--- a/src/lib/storyblok-types.ts
+++ b/src/lib/storyblok-types.ts
@@ -1,0 +1,35 @@
+import { SbBlokData } from "@storyblok/react/rsc";
+
+export interface EventCardBlok extends SbBlokData {
+  image: { filename: string };
+  title: string;
+  start: string;
+  venue: string;
+  summary?: string;
+  tags?: string[];
+  price?: string;
+}
+
+export type NavbarBlok = SbBlokData;
+
+export interface FiltersDrawerBlok extends SbBlokData {
+  categories?: string[];
+  price_min?: number;
+  price_max?: number;
+}
+
+export interface GridBlok extends SbBlokData {
+  columns?: SbBlokData[];
+}
+
+export interface PageBlok extends SbBlokData {
+  body?: SbBlokData[];
+}
+
+export interface TeaserBlok extends SbBlokData {
+  headline: string;
+}
+
+export interface FeatureBlok extends SbBlokData {
+  name: string;
+}

--- a/src/storyblok-components/EventCard.tsx
+++ b/src/storyblok-components/EventCard.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
 import { storyblokEditable } from "@storyblok/react/rsc";
+import type { EventCardBlok } from "@/lib/storyblok-types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function EventCard({ blok }: any) {
+export default function EventCard({ blok }: { blok: EventCardBlok }) {
   return (
     <article
       {...storyblokEditable(blok)}

--- a/src/storyblok-components/Feature.tsx
+++ b/src/storyblok-components/Feature.tsx
@@ -1,7 +1,7 @@
 import { storyblokEditable } from "@storyblok/react/rsc";
+import type { FeatureBlok } from "@/lib/storyblok-types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function Feature({ blok }: any) {
+export default function Feature({ blok }: { blok: FeatureBlok }) {
   return (
     <div {...storyblokEditable(blok)} className="py-4 text-center">
       <h3 className="text-lg font-semibold">{blok.name}</h3>

--- a/src/storyblok-components/FiltersDrawer.tsx
+++ b/src/storyblok-components/FiltersDrawer.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { storyblokEditable } from "@storyblok/react/rsc";
+import type { FiltersDrawerBlok } from "@/lib/storyblok-types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function FiltersDrawer({ blok }: any) {
+export default function FiltersDrawer({ blok }: { blok: FiltersDrawerBlok }) {
   return (
     <aside
       {...storyblokEditable(blok)}

--- a/src/storyblok-components/Grid.tsx
+++ b/src/storyblok-components/Grid.tsx
@@ -1,15 +1,16 @@
-import { storyblokEditable, StoryblokServerComponent } from "@storyblok/react/rsc";
+import {
+  storyblokEditable,
+  StoryblokServerComponent,
+  SbBlokData,
+} from "@storyblok/react/rsc";
+import type { GridBlok } from "@/lib/storyblok-types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function Grid({ blok }: any) {
+export default function Grid({ blok }: { blok: GridBlok }) {
   return (
     <div {...storyblokEditable(blok)} className="grid gap-6 md:grid-cols-3">
-      {blok.columns?.map(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (nestedBlok: any) => (
-          <StoryblokServerComponent blok={nestedBlok} key={nestedBlok._uid} />
-        )
-      )}
+      {blok.columns?.map((nestedBlok: SbBlokData) => (
+        <StoryblokServerComponent blok={nestedBlok} key={nestedBlok._uid} />
+      ))}
     </div>
   );
 }

--- a/src/storyblok-components/Navbar.tsx
+++ b/src/storyblok-components/Navbar.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { storyblokEditable } from "@storyblok/react/rsc";
+import type { NavbarBlok } from "@/lib/storyblok-types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function Navbar({ blok }: any) {
+export default function Navbar({ blok }: { blok: NavbarBlok }) {
   return (
     <header
       {...storyblokEditable(blok)}

--- a/src/storyblok-components/Page.tsx
+++ b/src/storyblok-components/Page.tsx
@@ -1,18 +1,16 @@
 import {
   StoryblokServerComponent,
   storyblokEditable,
+  SbBlokData,
 } from "@storyblok/react/rsc";
+import type { PageBlok } from "@/lib/storyblok-types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function Page({ blok }: any) {
+export default function Page({ blok }: { blok: PageBlok }) {
   return (
     <main {...storyblokEditable(blok)}>
-      {blok.body?.map(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (nestedBlok: any) => (
-          <StoryblokServerComponent blok={nestedBlok} key={nestedBlok._uid} />
-        )
-      )}
+      {blok.body?.map((nestedBlok: SbBlokData) => (
+        <StoryblokServerComponent blok={nestedBlok} key={nestedBlok._uid} />
+      ))}
     </main>
   );
 }

--- a/src/storyblok-components/Teaser.tsx
+++ b/src/storyblok-components/Teaser.tsx
@@ -1,7 +1,7 @@
 import { storyblokEditable } from "@storyblok/react/rsc";
+import type { TeaserBlok } from "@/lib/storyblok-types";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function Teaser({ blok }: any) {
+export default function Teaser({ blok }: { blok: TeaserBlok }) {
   return (
     <h2 {...storyblokEditable(blok)} className="my-4 text-2xl font-semibold">
       {blok.headline}


### PR DESCRIPTION
## Summary
- create typed Storyblok block interfaces
- replace `any` props with interfaces in Storyblok components
- keep `storyblokEditable` usage intact

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c75cc47e08327a74952e601afc45d