### PR TITLE
Add concurrent metadata requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ EVENTBRITE_TOKEN=
 MEETUP_KEY=
 TICKETMASTER_KEY=
 OPENAI_API_KEY=
+# Number of OpenAI requests to process in parallel
+OPENAI_CONCURRENT_REQUESTS=5
 
 # Base URL of the site (used for server fetches)
 NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@ cp .env.example .env
 - `MEETUP_KEY` – API key for Meetup
 - `TICKETMASTER_KEY` – API key for Ticketmaster
 - `OPENAI_API_KEY` – OpenAI API key used to enrich events
+- `OPENAI_CONCURRENT_REQUESTS` – how many metadata requests are sent in parallel (default 5)
 - `NEXT_PUBLIC_BASE_URL` – base URL of your site
 
 ## Events API
 
 The application exposes a `GET /api/events` route that aggregates events from the configured providers and enriches them with a short summary and tags using ChatGPT.
+
+Event enrichment calls OpenAI in small batches defined by `OPENAI_CONCURRENT_REQUESTS`. Adjust this value if you encounter rate limit errors.
 
 Visit `/events` to see the aggregated list rendered in the UI. Each event card displays the AI-generated summary and tags so you can quickly scan for topics of interest.


### PR DESCRIPTION
## Summary
- batch OpenAI requests with Promise.all
- document new `OPENAI_CONCURRENT_REQUESTS` env var and batching logic
- add example setting in `.env.example`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c75ee15e08327b34654eba85b47bd