### PR TITLE
Fix Storyblok env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cp .env.example .env
 - `MEETUP_KEY` – API key for Meetup
 - `TICKETMASTER_KEY` – API key for Ticketmaster
 - `OPENAI_API_KEY` – OpenAI API key used to enrich events
-- `STORYBLOK_TOKEN` – Storyblok API token used for content fetching
+ - `NEXT_PUBLIC_STORYBLOK_TOKEN` – Storyblok API token used for content fetching
 - `NEXT_PUBLIC_BASE_URL` – base URL of your site
 
 ## Events API

--- a/src/lib/storyblok.ts
+++ b/src/lib/storyblok.ts
@@ -11,9 +11,12 @@ import Teaser        from "@/storyblok-components/Teaser";
 import Feature       from "@/storyblok-components/Feature";
 
 // storyblokInit RETURNS a getStoryblokApi function ➜ we re-export it
-const accessToken = process.env.STORYBLOK_TOKEN;
+const accessToken =
+  process.env.NEXT_PUBLIC_STORYBLOK_TOKEN || process.env.STORYBLOK_TOKEN;
 if (!accessToken) {
-  throw new Error("STORYBLOK_TOKEN environment variable is missing");
+  throw new Error(
+    "NEXT_PUBLIC_STORYBLOK_TOKEN (or STORYBLOK_TOKEN) environment variable is missing",
+  );
 }
 
 export const getStoryblokApi = storyblokInit({


### PR DESCRIPTION
## Summary
- support public Storyblok token
- mention NEXT_PUBLIC_STORYBLOK_TOKEN in docs

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c7db5adf08327a8fe12ca91ea2294