### PR TITLE
Improve Storyblok env usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# API tokens for external services
+EVENTBRITE_TOKEN=
+MEETUP_KEY=
+TICKETMASTER_KEY=
+OPENAI_API_KEY=
+# Storyblok token (public for browser access)
+NEXT_PUBLIC_STORYBLOK_TOKEN=
+# Base URL of the site (used for server fetches)
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
+

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cp .env.example .env
 - `MEETUP_KEY` – API key for Meetup
 - `TICKETMASTER_KEY` – API key for Ticketmaster
 - `OPENAI_API_KEY` – OpenAI API key used to enrich events
-- `STORYBLOK_TOKEN` – Storyblok API token used for content fetching
+- `NEXT_PUBLIC_STORYBLOK_TOKEN` – Storyblok API token used for content fetching. Required for the Visual Editor so it must be prefixed with `NEXT_PUBLIC_`
 - `NEXT_PUBLIC_BASE_URL` – base URL of your site
 
 ## Events API

--- a/src/lib/storyblok.ts
+++ b/src/lib/storyblok.ts
@@ -1,24 +1,30 @@
-// Storyblok initialisation (runs ONCE, server side)
-import { apiPlugin, storyblokInit } from "@storyblok/react/rsc";
+// Storyblok initialization (runs once on the server)
+import {
+  apiPlugin,
+  storyblokInit,
+  getStoryblokApi,
+  StoryblokStory,
+} from "@storyblok/react/rsc";
 
-// 🔗 map your blok components
-import Navbar        from "@/storyblok-components/Navbar";
-import EventCard     from "@/storyblok-components/EventCard";
+import Navbar from "@/storyblok-components/Navbar";
+import EventCard from "@/storyblok-components/EventCard";
 import FiltersDrawer from "@/storyblok-components/FiltersDrawer";
-import Page          from "@/storyblok-components/Page";
-import Grid          from "@/storyblok-components/Grid";
-import Teaser        from "@/storyblok-components/Teaser";
-import Feature       from "@/storyblok-components/Feature";
+import Page from "@/storyblok-components/Page";
+import Grid from "@/storyblok-components/Grid";
+import Teaser from "@/storyblok-components/Teaser";
+import Feature from "@/storyblok-components/Feature";
 
-// storyblokInit RETURNS a getStoryblokApi function ➜ we re-export it
-const accessToken = process.env.STORYBLOK_TOKEN;
+const accessToken =
+  process.env.NEXT_PUBLIC_STORYBLOK_TOKEN ?? process.env.STORYBLOK_TOKEN;
 if (!accessToken) {
-  throw new Error("STORYBLOK_TOKEN environment variable is missing");
+  throw new Error(
+    "NEXT_PUBLIC_STORYBLOK_TOKEN (or STORYBLOK_TOKEN) environment variable is missing",
+  );
 }
 
-export const getStoryblokApi = storyblokInit({
+storyblokInit({
   accessToken,
-  use: [apiPlugin],                 // ← plugin really loaded now
+  use: [apiPlugin],
   components: {
     navbar: Navbar,
     event_card: EventCard,
@@ -30,5 +36,4 @@ export const getStoryblokApi = storyblokInit({
   },
 });
 
-// Server-side renderer for stories
-export { StoryblokStory } from "@storyblok/react/rsc";
+export { getStoryblokApi, StoryblokStory };


### PR DESCRIPTION
## Summary
- add `.env.example` to clarify all required environment variables
- document `NEXT_PUBLIC_STORYBLOK_TOKEN` in README
- init Storyblok once and re-export `getStoryblokApi`

## Testing
- `npm run lint`
- `NEXT_PUBLIC_STORYBLOK_TOKEN=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c7db5adf08327a8fe12ca91ea2294