### PR TITLE
Limit OpenAI requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ EVENTBRITE_TOKEN=
 MEETUP_KEY=
 TICKETMASTER_KEY=
 OPENAI_API_KEY=
+# Number of events to enrich via OpenAI per request (default 3)
+OPENAI_MAX_EVENTS=
 # Storyblok token (public for browser access)
 NEXT_PUBLIC_STORYBLOK_TOKEN=
 # Base URL of the site (used for server fetches)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ cp .env.example .env
 - `MEETUP_KEY` – API key for Meetup
 - `TICKETMASTER_KEY` – API key for Ticketmaster
 - `OPENAI_API_KEY` – OpenAI API key used to enrich events
+- `OPENAI_MAX_EVENTS` – maximum number of events to enrich with OpenAI per request (default 3)
 - `NEXT_PUBLIC_STORYBLOK_TOKEN` – Storyblok API token used for content fetching. Required for the Visual Editor so it must be prefixed with `NEXT_PUBLIC_`
 - `NEXT_PUBLIC_BASE_URL` – base URL of your site
 
@@ -59,3 +60,6 @@ cp .env.example .env
 The application exposes a `GET /api/events` route that aggregates events from the configured providers and enriches them with a short summary and tags using ChatGPT.
 
 Visit `/events` to see the aggregated list rendered in the UI. Each event card displays the AI-generated summary and tags so you can quickly scan for topics of interest.
+
+By default only the first few events are enriched via OpenAI to avoid hitting
+the free tier rate limit. Adjust `OPENAI_MAX_EVENTS` if you have a higher quota.

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -82,13 +82,17 @@ export async function GET() {
 
   const openaiKey = process.env.OPENAI_API_KEY;
   const openai = new OpenAI({ apiKey: openaiKey });
+  const maxOpenAIEvents = parseInt(process.env.OPENAI_MAX_EVENTS || '3', 10);
+  let openAIRequests = 0;
 
   const enriched: EnrichedEvent[] = [];
   for (const event of events as FetchedEvent[]) {
     try {
-      const metadata = openaiKey
+      const shouldEnrich = openaiKey && openAIRequests < maxOpenAIEvents;
+      const metadata = shouldEnrich
         ? await generateEventMetadata(event, openai)
         : { summary: '', tags: [] };
+      if (shouldEnrich) openAIRequests++;
       enriched.push({
         id: event.id,
 


### PR DESCRIPTION
## Summary
- avoid rate limit errors by limiting the number of events we enrich via OpenAI
- document new `OPENAI_MAX_EVENTS` variable and explain default behavior

## Testing
- `npm install`
- `npm run lint`
- `npm run build` *(fails: NEXT_PUBLIC_STORYBLOK_TOKEN environment variable is missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e13f839b48327a6fbef4a26a6bdf6