### PR TITLE
Add placeholder image & begin search feature

### DIFF
--- a/public/placeholder.svg
+++ b/public/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="160" viewBox="0 0 320 160" preserveAspectRatio="none">
+  <rect width="320" height="160" fill="#ccc" />
+  <text x="160" y="80" font-size="20" text-anchor="middle" fill="#666" dy=".3em">Image</text>
+</svg>

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,4 +1,4 @@
-import EventCard from '@/storyblok-components/EventCard';
+import EventsSearch from '@/components/EventsSearch';
 
 interface ApiEvent {
   id: string;
@@ -21,23 +21,7 @@ export default async function EventsPage() {
   return (
     <div className="space-y-6 p-6">
       <h1 className="text-2xl font-semibold">Upcoming Events</h1>
-      <div className="grid gap-6 md:grid-cols-3">
-        {events.map(event => (
-          <EventCard
-            key={event.id}
-          blok={{
-            _uid: event.id,
-            image: { filename: '/placeholder.jpg' },
-            title: event.title,
-            start: event.start,
-            venue: event.venue,
-            summary: event.summary,
-            tags: event.tags,
-            price: '',
-          }}
-          />
-        ))}
-      </div>
+      <EventsSearch events={events} />
     </div>
   );
 }

--- a/src/components/EventsSearch.tsx
+++ b/src/components/EventsSearch.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useMemo, useState } from "react";
+import EventCard from "@/storyblok-components/EventCard";
+import SearchBar from "@/storyblok-components/SearchBar";
+
+interface ApiEvent {
+  id: string;
+  title: string;
+  url?: string;
+  start?: string;
+  venue?: string;
+  summary: string;
+  tags: string[];
+}
+
+export default function EventsSearch({ events }: { events: ApiEvent[] }) {
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    return events.filter((e) => e.title.toLowerCase().includes(q));
+  }, [events, query]);
+
+  return (
+    <div>
+      <SearchBar blok={{ _uid: "search", placeholder: "Search events" }} onSearch={setQuery} />
+      <div className="grid gap-6 md:grid-cols-3">
+        {filtered.map((event) => (
+          <EventCard
+            key={event.id}
+            blok={{
+              _uid: event.id,
+              image: { filename: "/placeholder.svg" },
+              title: event.title,
+              start: event.start,
+              venue: event.venue,
+              summary: event.summary,
+              tags: event.tags,
+              price: "",
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/storyblok-types.ts
+++ b/src/lib/storyblok-types.ts
@@ -12,6 +12,10 @@ export interface EventCardBlok extends SbBlokData {
 
 export type NavbarBlok = SbBlokData;
 
+export interface SearchBarBlok extends SbBlokData {
+  placeholder?: string;
+}
+
 export interface FiltersDrawerBlok extends SbBlokData {
   categories?: string[];
   price_min?: number;

--- a/src/lib/storyblok.ts
+++ b/src/lib/storyblok.ts
@@ -13,6 +13,7 @@ import Page from "@/storyblok-components/Page";
 import Grid from "@/storyblok-components/Grid";
 import Teaser from "@/storyblok-components/Teaser";
 import Feature from "@/storyblok-components/Feature";
+import SearchBar from "@/storyblok-components/SearchBar";
 
 const accessToken =
   process.env.NEXT_PUBLIC_STORYBLOK_TOKEN ?? process.env.STORYBLOK_TOKEN;
@@ -34,6 +35,7 @@ storyblokInit({
     grid: Grid,
     teaser: Teaser,
     feature: Feature,
+    search_bar: SearchBar,
   },
 });
 

--- a/src/storyblok-components/EventCard.tsx
+++ b/src/storyblok-components/EventCard.tsx
@@ -9,7 +9,7 @@ export default function EventCard({ blok }: { blok: EventCardBlok }) {
       className="w-80 rounded-xl overflow-hidden shadow transition hover:shadow-lg"
     >
       <Image
-        src={blok.image.filename ?? `/placeholder.jpg`}
+        src={blok.image.filename ?? `/placeholder.svg`}
         alt={blok.title}
         width={320}
         height={160}

--- a/src/storyblok-components/SearchBar.tsx
+++ b/src/storyblok-components/SearchBar.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { storyblokEditable } from "@storyblok/react/rsc";
+import { useState } from "react";
+import type { SearchBarBlok } from "@/lib/storyblok-types";
+
+export default function SearchBar({ blok, onSearch }: { blok: SearchBarBlok; onSearch?: (q: string) => void }) {
+  const [query, setQuery] = useState("");
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const q = e.target.value;
+    setQuery(q);
+    onSearch?.(q);
+  }
+
+  return (
+    <div {...storyblokEditable(blok)}>
+      <input
+        value={query}
+        onChange={handleChange}
+        placeholder={blok.placeholder || "Search"}
+        className="w-full h-9 rounded-md border px-3 text-sm focus:outline-none"
+      />
+    </div>
+  );
+}

--- a/src/storyblok-components/index.ts
+++ b/src/storyblok-components/index.ts
@@ -5,4 +5,5 @@ export { default as Page } from "./Page";
 export { default as Grid } from "./Grid";
 export { default as Teaser } from "./Teaser";
 export { default as Feature } from "./Feature";
+export { default as SearchBar } from "./SearchBar";
 

--- a/storyblok/components.342149.json
+++ b/storyblok/components.342149.json
@@ -29,6 +29,12 @@
       }
     },
     {
+      "name": "search_bar",
+      "display_name": "Search Bar",
+      "is_nestable": true,
+      "schema": { "placeholder": { "type": "text" } }
+    },
+    {
       "name": "page",
       "display_name": "Page",
       "is_root":  true,


### PR DESCRIPTION
## Summary
- add missing placeholder image to avoid broken events
- update event card to use placeholder
- add search components and Storyblok schema
- integrate search into events page

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e23ca7adc8327b6a66026c5083ec2