### PR TITLE
Improve events page with images, filters and landing info

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    domains: [
+      'img.evbuc.com',
+      'secure.meetupstatic.com',
+      's1.ticketm.net',
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -43,6 +43,9 @@ interface FetchedEvent {
   local_date?: string;
   venue?: { name?: string };
   _embedded?: { venues?: { name?: string }[] };
+  logo?: { url?: string; original?: { url?: string } };
+  featured_photo?: { photo_link?: string; highres_link?: string };
+  images?: { url?: string }[];
 }
 
 interface EnrichedEvent {
@@ -51,6 +54,7 @@ interface EnrichedEvent {
   url?: string;
   start?: string;
   venue?: string;
+  image?: string;
   summary: string;
   tags: string[];
 }
@@ -104,6 +108,16 @@ export async function GET() {
             ? event.start
             : event.start?.local || event.local_date,
         venue: event.venue?.name || event._embedded?.venues?.[0]?.name || '',
+        image:
+          // Eventbrite
+          event.logo?.original?.url ||
+          event.logo?.url ||
+          // Meetup
+          event.featured_photo?.highres_link ||
+          event.featured_photo?.photo_link ||
+          // Ticketmaster
+          event.images?.[0]?.url ||
+          '',
         summary: metadata.summary,
         tags: metadata.tags,
       });

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -6,6 +6,7 @@ interface ApiEvent {
   url: string;
   start: string;
   venue: string;
+  image?: string;
   summary: string;
   tags: string[];
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,10 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.glass {
+  background: rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,20 @@
-import { StoryblokStory } from "@storyblok/react/rsc";
-import { getStoryblokApi } from "@/lib/storyblok";   // ← import YOUR helper
-
-export default async function Home() {
-  const sbApi = getStoryblokApi(); // apiPlugin already active
-  try {
-    const { data } = await sbApi.get("cdn/stories/home", { version: "draft" });
-    return <StoryblokStory story={data.story} />;
-  } catch (err) {
-    console.error(err);
-    return <div>Failed to load</div>;
-  }
+export default function Home() {
+  return (
+    <main className="p-6 space-y-6">
+      <h1 className="text-3xl font-bold">Welcome to EventFinder</h1>
+      <p>
+        EventFinder aggregates happenings from Eventbrite, Meetup and Ticketmaster and enriches them with AI summaries and tags so you can quickly discover interesting events.
+      </p>
+      <ul className="list-disc pl-6 space-y-2">
+        <li>Browse events from multiple providers in one place</li>
+        <li>AI generated summaries and tags help you understand each event at a glance</li>
+        <li>Free text search across titles, descriptions and tags</li>
+        <li>Filter events by tags using the handy tag selectors</li>
+        <li>Sleek interface with glass styled buttons</li>
+      </ul>
+      <p>
+        Get started by visiting the <a className="text-blue-600 underline" href="/events">events page</a>.
+      </p>
+    </main>
+  );
 }

--- a/src/components/EventsSearch.tsx
+++ b/src/components/EventsSearch.tsx
@@ -9,31 +9,65 @@ interface ApiEvent {
   url?: string;
   start?: string;
   venue?: string;
+  image?: string;
   summary: string;
   tags: string[];
 }
 
 export default function EventsSearch({ events }: { events: ApiEvent[] }) {
   const [query, setQuery] = useState("");
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+  function toggleTag(tag: string) {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  }
+
+  const allTags = useMemo(() => {
+    const tags = new Set<string>();
+    events.forEach((e) => e.tags.forEach((t) => tags.add(t)));
+    return Array.from(tags);
+  }, [events]);
 
   const filtered = useMemo(() => {
     const q = query.toLowerCase();
-    return events.filter((e) => e.title.toLowerCase().includes(q));
-  }, [events, query]);
+    return events.filter((e) => {
+      const text = `${e.title} ${e.summary} ${e.venue} ${e.tags.join(' ')}`.toLowerCase();
+      const matchesQuery = text.includes(q);
+      const matchesTags =
+        selectedTags.length === 0 ||
+        selectedTags.every((t) => e.tags.includes(t));
+      return matchesQuery && matchesTags;
+    });
+  }, [events, query, selectedTags]);
 
   return (
     <div>
       <SearchBar blok={{ _uid: "search", placeholder: "Search events" }} onSearch={setQuery} />
+      <div className="my-4 flex flex-wrap gap-2">
+        {allTags.map((tag) => (
+          <label key={tag} className="glass px-3 py-1 rounded cursor-pointer text-sm">
+            <input
+              type="checkbox"
+              className="mr-1"
+              checked={selectedTags.includes(tag)}
+              onChange={() => toggleTag(tag)}
+            />
+            {tag}
+          </label>
+        ))}
+      </div>
       <div className="grid gap-6 md:grid-cols-3">
         {filtered.map((event) => (
           <EventCard
             key={event.id}
             blok={{
               _uid: event.id,
-              image: { filename: "/placeholder.svg" },
+              image: { filename: event.image || "/placeholder.svg" },
               title: event.title,
-              start: event.start,
-              venue: event.venue,
+              start: event.start || '',
+              venue: event.venue || '',
               summary: event.summary,
               tags: event.tags,
               price: "",

--- a/src/components/StoryblokProvider.tsx
+++ b/src/components/StoryblokProvider.tsx
@@ -3,6 +3,8 @@ import { getStoryblokApi } from "@/lib/storyblok";
 
 /**  Enables the Visual Editor bridge on the client */
 export default function StoryblokProvider({ children }: { children: React.ReactNode }) {
-  getStoryblokApi();        // loads bridge once on the client
+  if (process.env.NEXT_PUBLIC_STORYBLOK_TOKEN || process.env.STORYBLOK_TOKEN) {
+    getStoryblokApi(); // loads bridge once on the client
+  }
   return children;
 }

--- a/src/lib/storyblok.ts
+++ b/src/lib/storyblok.ts
@@ -18,25 +18,21 @@ import SearchBar from "@/storyblok-components/SearchBar";
 const accessToken =
   process.env.NEXT_PUBLIC_STORYBLOK_TOKEN ?? process.env.STORYBLOK_TOKEN;
 
-if (!accessToken) {
-  throw new Error(
-    "NEXT_PUBLIC_STORYBLOK_TOKEN (or STORYBLOK_TOKEN) environment variable is missing",
-  );
+if (accessToken) {
+  storyblokInit({
+    accessToken,
+    use: [apiPlugin],
+    components: {
+      navbar: Navbar,
+      event_card: EventCard,
+      filters_drawer: FiltersDrawer,
+      page: Page,
+      grid: Grid,
+      teaser: Teaser,
+      feature: Feature,
+      search_bar: SearchBar,
+    },
+  });
 }
-
-storyblokInit({
-  accessToken,
-  use: [apiPlugin],
-  components: {
-    navbar: Navbar,
-    event_card: EventCard,
-    filters_drawer: FiltersDrawer,
-    page: Page,
-    grid: Grid,
-    teaser: Teaser,
-    feature: Feature,
-    search_bar: SearchBar,
-  },
-});
 
 export { getStoryblokApi, StoryblokStory };

--- a/src/storyblok-components/SearchBar.tsx
+++ b/src/storyblok-components/SearchBar.tsx
@@ -18,7 +18,7 @@ export default function SearchBar({ blok, onSearch }: { blok: SearchBarBlok; onS
         value={query}
         onChange={handleChange}
         placeholder={blok.placeholder || "Search"}
-        className="w-full h-9 rounded-md border px-3 text-sm focus:outline-none"
+        className="glass w-full h-9 rounded-md px-3 text-sm focus:outline-none"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- fetch event images from providers and show them on cards
- add filter UI with tag selection and full-text search
- apply "glass" styling utility class and use it in the search bar and filters
- allow Storyblok to be optional so the build works without a token
- create a simple landing page describing the app features
- configure remote image domains in Next.js

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e26f1c0048327a4dff6ab9ee0276a