### PR TITLE
Enhance UI with navbar and new features

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -11,7 +11,7 @@ interface ApiEvent {
   tags: string[];
 }
 
-export default async function EventsPage() {
+export default async function EventsPage({ searchParams }: { searchParams?: { q?: string } }) {
   const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/events`, { cache: 'no-store' });
   if (!res.ok) {
     throw new Error('Failed to load events');
@@ -22,7 +22,7 @@ export default async function EventsPage() {
   return (
     <div className="space-y-6 p-6">
       <h1 className="text-2xl font-semibold">Upcoming Events</h1>
-      <EventsSearch events={events} />
+      <EventsSearch events={events} initialQuery={searchParams?.q || ''} />
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,7 @@
   --font-mono: var(--font-geist-mono);
 }
 
+
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
@@ -19,10 +20,16 @@
   }
 }
 
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans, Arial, Helvetica, sans-serif);
+  transition: background 0.3s, color 0.3s;
 }
 
 .glass {
@@ -30,4 +37,9 @@ body {
   backdrop-filter: blur(8px);
   border: 1px solid rgba(255, 255, 255, 0.3);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.dark .glass {
+  background: rgba(30, 30, 30, 0.4);
+  border-color: rgba(255, 255, 255, 0.2);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,15 @@
 import StoryblokProvider from "@/components/StoryblokProvider";
+import Navbar from "@/storyblok-components/Navbar";
+import "./globals.css";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <StoryblokProvider>
       <html lang="en">
-        <body>{children}</body>
+        <body className="min-h-screen flex flex-col">
+          <Navbar blok={{ _uid: "navbar" }} />
+          <main className="flex-1 container mx-auto px-4 py-6">{children}</main>
+        </body>
       </html>
     </StoryblokProvider>
   );

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -1,0 +1,10 @@
+import SavedEvents from "@/components/SavedEvents";
+
+export default function SavedPage() {
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Saved Events</h1>
+      <SavedEvents />
+    </div>
+  );
+}

--- a/src/components/EventsSearch.tsx
+++ b/src/components/EventsSearch.tsx
@@ -14,9 +14,11 @@ interface ApiEvent {
   tags: string[];
 }
 
-export default function EventsSearch({ events }: { events: ApiEvent[] }) {
-  const [query, setQuery] = useState("");
+export default function EventsSearch({ events, initialQuery = "" }: { events: ApiEvent[]; initialQuery?: string }) {
+  const [query, setQuery] = useState(initialQuery);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [sort, setSort] = useState<'asc' | 'desc'>('asc');
+  const [active, setActive] = useState<ApiEvent | null>(null);
 
   function toggleTag(tag: string) {
     setSelectedTags((prev) =>
@@ -32,7 +34,7 @@ export default function EventsSearch({ events }: { events: ApiEvent[] }) {
 
   const filtered = useMemo(() => {
     const q = query.toLowerCase();
-    return events.filter((e) => {
+    const list = events.filter((e) => {
       const text = `${e.title} ${e.summary} ${e.venue} ${e.tags.join(' ')}`.toLowerCase();
       const matchesQuery = text.includes(q);
       const matchesTags =
@@ -40,12 +42,17 @@ export default function EventsSearch({ events }: { events: ApiEvent[] }) {
         selectedTags.every((t) => e.tags.includes(t));
       return matchesQuery && matchesTags;
     });
-  }, [events, query, selectedTags]);
+    return list.sort((a, b) => {
+      const da = new Date(a.start || '').getTime();
+      const db = new Date(b.start || '').getTime();
+      return sort === 'asc' ? da - db : db - da;
+    });
+  }, [events, query, selectedTags, sort]);
 
   return (
     <div>
       <SearchBar blok={{ _uid: "search", placeholder: "Search events" }} onSearch={setQuery} />
-      <div className="my-4 flex flex-wrap gap-2">
+      <div className="my-4 flex flex-wrap gap-2 items-center">
         {allTags.map((tag) => (
           <label key={tag} className="glass px-3 py-1 rounded cursor-pointer text-sm">
             <input
@@ -57,24 +64,68 @@ export default function EventsSearch({ events }: { events: ApiEvent[] }) {
             {tag}
           </label>
         ))}
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as 'asc' | 'desc')}
+          className="ml-auto border rounded px-2 py-1 text-sm"
+        >
+          <option value="asc">Date ↑</option>
+          <option value="desc">Date ↓</option>
+        </select>
       </div>
       <div className="grid gap-6 md:grid-cols-3">
         {filtered.map((event) => (
-          <EventCard
-            key={event.id}
-            blok={{
-              _uid: event.id,
-              image: { filename: event.image || "/placeholder.svg" },
-              title: event.title,
-              start: event.start || '',
-              venue: event.venue || '',
-              summary: event.summary,
-              tags: event.tags,
-              price: "",
-            }}
-          />
+          <div key={event.id} onClick={() => setActive(event)}>
+            <EventCard
+              blok={{
+                _uid: event.id,
+                image: { filename: event.image || "/placeholder.svg" },
+                title: event.title,
+                start: event.start || '',
+                venue: event.venue || '',
+                summary: event.summary,
+                tags: event.tags,
+                price: "",
+              }}
+            />
+          </div>
         ))}
       </div>
+      {active && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+          onClick={() => setActive(null)}
+        >
+          <div
+            className="bg-white dark:bg-gray-800 p-6 rounded-lg max-w-md w-full"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-xl font-semibold mb-2">{active.title}</h2>
+            <p className="text-sm mb-2">{active.summary}</p>
+            <p className="text-sm text-slate-600 mb-4">{active.venue}</p>
+            <div className="flex justify-between mt-4">
+              <a
+                href={active.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-blue-600 underline"
+              >
+                View Event
+              </a>
+              {active.venue && (
+                <a
+                  href={`https://www.google.com/maps/search/${encodeURIComponent(active.venue)}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-blue-600 underline"
+                >
+                  Map
+                </a>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/SavedEvents.tsx
+++ b/src/components/SavedEvents.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useEffect, useState } from "react";
+import EventCard from "@/storyblok-components/EventCard";
+import type { EventCardBlok } from "@/lib/storyblok-types";
+
+export default function SavedEvents() {
+  const [events, setEvents] = useState<EventCardBlok[]>([]);
+
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem("savedEvents") || "[]");
+    setEvents(stored);
+  }, []);
+
+  if (events.length === 0) {
+    return <p>You have no saved events.</p>;
+  }
+
+  return (
+    <div className="grid gap-6 md:grid-cols-3">
+      {events.map((blok) => (
+        <EventCard key={blok._uid} blok={blok} />
+      ))}
+    </div>
+  );
+}

--- a/src/storyblok-components/EventCard.tsx
+++ b/src/storyblok-components/EventCard.tsx
@@ -1,12 +1,35 @@
+"use client";
 import Image from "next/image";
 import { storyblokEditable } from "@storyblok/react/rsc";
+import { useEffect, useState } from "react";
 import type { EventCardBlok } from "@/lib/storyblok-types";
 
 export default function EventCard({ blok }: { blok: EventCardBlok }) {
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem("savedEvents") || "[]");
+    setSaved(stored.some((e: EventCardBlok) => e._uid === blok._uid));
+  }, [blok._uid]);
+
+  function toggleSaved(e: React.MouseEvent) {
+    e.stopPropagation();
+    const stored = JSON.parse(localStorage.getItem("savedEvents") || "[]");
+    if (saved) {
+      const next = stored.filter((e: EventCardBlok) => e._uid !== blok._uid);
+      localStorage.setItem("savedEvents", JSON.stringify(next));
+      setSaved(false);
+    } else {
+      stored.push(blok);
+      localStorage.setItem("savedEvents", JSON.stringify(stored));
+      setSaved(true);
+    }
+  }
+
   return (
     <article
       {...storyblokEditable(blok)}
-      className="w-80 rounded-xl overflow-hidden shadow transition hover:shadow-lg"
+      className="w-80 rounded-xl overflow-hidden shadow transition hover:shadow-lg bg-white dark:bg-gray-800 cursor-pointer"
     >
       <Image
         src={blok.image.filename ?? `/placeholder.svg`}
@@ -15,7 +38,20 @@ export default function EventCard({ blok }: { blok: EventCardBlok }) {
         height={160}
         className="object-cover h-40 w-full"
       />
-      <div className="p-4 space-y-1">
+      <div className="p-4 space-y-1 relative">
+        <button
+          onClick={toggleSaved}
+          aria-label="Save event"
+          className="absolute top-2 right-2 text-white"
+        >
+          <span
+            className={
+              saved
+                ? "i-lucide-bookmark w-5 h-5"
+                : "i-lucide-bookmark w-5 h-5 opacity-50"
+            }
+          />
+        </button>
         <span className="text-xs text-slate-500">{blok.start}</span>
         <h3 className="text-lg font-medium">{blok.title}</h3>
         <p className="text-sm text-slate-600">{blok.venue}</p>

--- a/src/storyblok-components/Navbar.tsx
+++ b/src/storyblok-components/Navbar.tsx
@@ -1,21 +1,64 @@
 "use client";
 import { storyblokEditable } from "@storyblok/react/rsc";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 import type { NavbarBlok } from "@/lib/storyblok-types";
 
 export default function Navbar({ blok }: { blok: NavbarBlok }) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") === "dark";
+    setDark(stored);
+    if (stored) document.documentElement.classList.add("dark");
+  }, []);
+
+  function toggleDark() {
+    const next = !dark;
+    setDark(next);
+    if (next) {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    }
+  }
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    router.push(`/events?q=${encodeURIComponent(query)}`);
+  }
+
   return (
     <header
       {...storyblokEditable(blok)}
-      className="flex items-center justify-between px-4 h-16 bg-white shadow"
+      className="flex items-center justify-between px-6 h-16 bg-white dark:bg-gray-900 shadow"
     >
       <span className="text-xl font-semibold">EventFinder</span>
-      <input
-        placeholder="Search events"
-        className="w-56 h-9 rounded-md border px-3 text-sm focus:outline-none"
-      />
-      <div className="flex gap-4">
-        <button aria-label="Saved" className="i-lucide-bookmark w-5 h-5" />
-        <button aria-label="Profile" className="i-lucide-user w-5 h-5" />
+      <form onSubmit={handleSearch} className="flex-1 mx-6 max-w-md">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search events"
+          className="w-full h-9 rounded-md border px-3 text-sm focus:outline-none bg-white/70 dark:bg-gray-800 dark:border-gray-700"
+        />
+      </form>
+      <div className="flex gap-4 items-center">
+        <button
+          aria-label="Saved"
+          onClick={() => router.push("/saved")}
+          className="i-lucide-bookmark w-5 h-5 hover:text-orange-500"
+        />
+        <button
+          aria-label="Toggle theme"
+          onClick={toggleDark}
+          className="w-5 h-5"
+        >
+          <span className={dark ? "i-lucide-sun" : "i-lucide-moon"}></span>
+        </button>
       </div>
     </header>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}',
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add global Navbar with search and theme toggle
- implement dark mode and glass style tweaks
- allow saving events on EventCard
- allow sorting, modal details and dark mode in EventsSearch
- support initial search query on events page
- show saved events on new page
- configure Tailwind for class-based dark mode

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e2ea68ad0832798b3378aca0e8e65